### PR TITLE
Mark the biblereader as EOL

### DIFF
--- a/appdata.patch
+++ b/appdata.patch
@@ -1,14 +1,48 @@
+From a9a4f9f0655f85a65728ca9935dc59869c3258c1 Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Thu, 20 Jun 2024 23:14:11 +0300
+Subject: [PATCH] fix appdata
+
+---
+ org.homelinuxserver.vance.biblereader.appdata.xml | 6 +++++-
+ org.homelinuxserver.vance.biblereader.desktop     | 1 +
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
 diff --git a/org.homelinuxserver.vance.biblereader.appdata.xml b/org.homelinuxserver.vance.biblereader.appdata.xml
-index 11db556..0bd384a 100644
+index 11db556..b5e42f3 100644
 --- a/org.homelinuxserver.vance.biblereader.appdata.xml
 +++ b/org.homelinuxserver.vance.biblereader.appdata.xml
-@@ -28,6 +28,9 @@
+@@ -5,6 +5,7 @@
+ 	<project_license>LGPL-3.0+ AND GPL-3.0+</project_license>
+ 	<name>Biblereader</name>
+ 	<summary>Read the Word</summary>
++	<developer_name>Nathan Vance</developer_name>
+ 
+ 	<description>
+ 		<p>
+@@ -27,8 +28,11 @@
+ 			<image>https://gitlab.com/natervance/biblereader/raw/dfbd4447c0173f4112b972ceead9295c3042ef1e/screenshots/biblereader-passageselect.png</image>
  		</screenshot>
  	</screenshots>
- 
-+	<releases> 
++	<releases>
 +		<release version="1.0.3" date="2019-04-26"/>
 +	</releases>
- 	<url type="homepage">https://gitlab.com/natervance/biblereader</url>
- 	<content_rating type="oars-1.0" />
  
+ 	<url type="homepage">https://gitlab.com/natervance/biblereader</url>
+-	<content_rating type="oars-1.0" />
++	<content_rating type="oars-1.1" />
+ 
+ </component>   
+diff --git a/org.homelinuxserver.vance.biblereader.desktop b/org.homelinuxserver.vance.biblereader.desktop
+index 7a2a9a4..96d2b96 100644
+--- a/org.homelinuxserver.vance.biblereader.desktop
++++ b/org.homelinuxserver.vance.biblereader.desktop
+@@ -4,4 +4,5 @@ Type=Application
+ Name=Biblereader
+ Comment=Read the Word
+ Exec=biblereader
++Categories=Education;Spirituality;
+ Icon=org.homelinuxserver.vance.biblereader-symbolic
+--
+libgit2 1.7.2
+

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+	"end-of-life": "This application is no longer maintained."
+}

--- a/org.homelinuxserver.vance.biblereader.json
+++ b/org.homelinuxserver.vance.biblereader.json
@@ -134,10 +134,9 @@
             "name" : "biblereader",
             "sources" : [
                 {
-                    "type" : "git",
-                    "url" : "https://gitlab.com/natervance/biblereader.git",
-                    "tag" : "1.0.3",
-                    "commit" : "e827d61973c6f02fbc88e99c6b0b01f6c5f9c472"
+                    "type" : "archive",
+                    "url" : "https://gitlab.com/natervance/biblereader/-/archive/1.0.3/biblereader-1.0.3.tar.gz",
+                    "sha256" : "329c2bdbd520406ed73eb882ad51fbd975003bef74d6e90037725a2fdb291892"
                 },
                 {
                     "type" : "patch",


### PR DESCRIPTION
> It seems the maintainer deleted their Github account. There's little point in continuing to merge updates here.

https://github.com/flathub/org.homelinuxserver.vance.biblereader/pull/2#issuecomment-2180789003